### PR TITLE
Remove unavailable Reuters and The Verge sources

### DIFF
--- a/src/data/predefined-sources.json
+++ b/src/data/predefined-sources.json
@@ -18,12 +18,6 @@
           "language": "en"
         },
         {
-          "name": "The Verge",
-          "url": "https://www.theverge.com/rss/index.xml",
-          "description": "Technology, art, science, and culture",
-          "language": "en"
-        },
-        {
           "name": "Wired",
           "url": "https://www.wired.com/feed/rss",
           "description": "Ideas that matter in technology",
@@ -52,12 +46,6 @@
           "name": "BBC News",
           "url": "http://feeds.bbci.co.uk/news/rss.xml",
           "description": "International news from the BBC",
-          "language": "en"
-        },
-        {
-          "name": "Reuters",
-          "url": "https://feeds.reuters.com/reuters/topNews",
-          "description": "World news and business",
           "language": "en"
         },
         {


### PR DESCRIPTION
## Summary
- remove the predefined Reuters and The Verge feeds that can no longer be selected safely

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d982088784832999c1d58273a468ef