### PR TITLE
Preselect news category on FTU onboarding

### DIFF
--- a/src/views/ftu/FirstTimeUser.tsx
+++ b/src/views/ftu/FirstTimeUser.tsx
@@ -45,7 +45,9 @@ export const FirstTimeUser = () => {
   const canContinue = totalSources > 0;
 
   const predefinedSourcesData = getPredefinedSources();
-  const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set());
+  const [selectedCategories, setSelectedCategories] = useState<Set<string>>(
+    () => new Set(['news'])
+  );
   const [selectedLanguage, setSelectedLanguage] = useState<SupportedLanguage | 'all'>('all');
 
   const handleCategorySelect = (categoryId: string) => {


### PR DESCRIPTION
## Summary
- default the first-time user experience to highlight the News category so new users immediately see relevant sources

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9f7111b4c8329a41d1ec86e587bc7