### PR TITLE
Allow deselecting predefined sources in FTU

### DIFF
--- a/src/components/DiscoverSourceCard.tsx
+++ b/src/components/DiscoverSourceCard.tsx
@@ -6,9 +6,12 @@ type DiscoverSourceCardProps = {
   source: PredefinedSource;
   isAdded: boolean;
   onAdd: (sourceUrl: string) => void;
+  onRemove?: (sourceUrl: string) => void;
 };
 
-export const DiscoverSourceCard = ({ source, isAdded, onAdd }: DiscoverSourceCardProps) => {
+export const DiscoverSourceCard = ({ source, isAdded, onAdd, onRemove }: DiscoverSourceCardProps) => {
+  const canRemove = Boolean(onRemove);
+
   return (
     <div
       className={`
@@ -21,26 +24,40 @@ export const DiscoverSourceCard = ({ source, isAdded, onAdd }: DiscoverSourceCar
       `}
     >
       {/* Action indicator */}
-      <div className={`
-        absolute top-3 right-3 w-8 h-8 rounded-full border-2 transition-all duration-200 flex items-center justify-center
-        ${
-          isAdded
-            ? 'border-green-500 dark:border-green-400 bg-green-500 dark:bg-green-400'
-            : 'border-zinc-400 dark:border-zinc-600 bg-transparent group-hover:border-zinc-500 dark:group-hover:border-zinc-500 cursor-pointer'
-        }
-      `}>
+      <button
+        type="button"
+        className={`
+          absolute top-3 right-3 w-8 h-8 rounded-full border-2 transition-all duration-200 flex items-center justify-center
+          ${
+            isAdded
+              ? `border-green-500 dark:border-green-400 bg-green-500 dark:bg-green-400 ${
+                  canRemove
+                    ? 'hover:bg-green-600 dark:hover:bg-green-300'
+                    : 'opacity-80 cursor-not-allowed'
+                }`
+              : 'border-zinc-400 dark:border-zinc-600 bg-transparent group-hover:border-zinc-500 dark:group-hover:border-zinc-500'
+          }
+        `}
+        onClick={(event) => {
+          event.stopPropagation();
+          if (isAdded) {
+            if (!canRemove) {
+              return;
+            }
+            onRemove?.(source.url);
+          } else {
+            onAdd(source.url);
+          }
+        }}
+        aria-label={isAdded ? (canRemove ? 'Remove source' : 'Source already added') : 'Add source'}
+        disabled={isAdded && !canRemove}
+      >
         {isAdded ? (
           <Check className="w-4 h-4 text-white dark:text-zinc-900" />
         ) : (
-          <Plus
-            className="w-4 h-4 text-zinc-700 dark:text-zinc-300 group-hover:text-zinc-800 dark:group-hover:text-zinc-200"
-            onClick={(e) => {
-              e.stopPropagation();
-              onAdd(source.url);
-            }}
-          />
+          <Plus className="w-4 h-4 text-zinc-700 dark:text-zinc-300 group-hover:text-zinc-800 dark:group-hover:text-zinc-200" />
         )}
-      </div>
+      </button>
 
       {/* Source info */}
       <div className="pr-10 flex items-start gap-3">
@@ -86,7 +103,7 @@ export const DiscoverSourceCard = ({ source, isAdded, onAdd }: DiscoverSourceCar
             <div className="mt-2">
               <span className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200 text-xs font-medium">
                 <Check className="w-3 h-3" />
-                Added
+                {canRemove ? 'Added · Click to remove' : 'Added'}
               </span>
             </div>
           )}

--- a/src/views/ftu/FirstTimeUser.tsx
+++ b/src/views/ftu/FirstTimeUser.tsx
@@ -98,6 +98,23 @@ export const FirstTimeUser = () => {
     }
   };
 
+  const handleRemoveSource = (sourceUrl: string) => {
+    const existingSource = state.sources.find(source => source.url === sourceUrl);
+
+    if (!existingSource) {
+      showError("Source not found!", "warning");
+      return;
+    }
+
+    const updatedSources = state.sources.filter(source => source.url !== sourceUrl);
+    const updatedActiveSources = state.activeSources.filter(id => id !== existingSource.id);
+
+    dispatch({ type: ActionTypes.SET_SOURCES, payload: updatedSources });
+    dispatch({ type: ActionTypes.SET_ACTIVE_SOURCES, payload: updatedActiveSources });
+
+    showError("Source removed successfully!", "success");
+  };
+
   const allSelectedSources = selectedCategories.size === 0 
     ? [] 
     : predefinedSourcesData.categories
@@ -208,6 +225,7 @@ export const FirstTimeUser = () => {
                       source={source}
                       isAdded={addedSourceUrls.has(source.url)}
                       onAdd={() => handleAddSource(source.url)}
+                      onRemove={() => handleRemoveSource(source.url)}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
## Summary
- add removal handling for preselected sources in the FTU flow so users can undo selections
- enhance DiscoverSourceCard to support toggling sources with accessible button states and updated messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da0955a3d88329aa11671ce2521c6f