### PR TITLE
Allow toggling recommended sources

### DIFF
--- a/src/components/DiscoverSourceCard.tsx
+++ b/src/components/DiscoverSourceCard.tsx
@@ -1,14 +1,14 @@
-import { Check, Plus, Rss } from "lucide-react";
+import { Check, Minus, Plus, Rss } from "lucide-react";
 
 import { PredefinedSource } from "../types/predefined-sources";
 
 type DiscoverSourceCardProps = {
   source: PredefinedSource;
   isAdded: boolean;
-  onAdd: (sourceUrl: string) => void;
+  onToggle: (sourceUrl: string) => void;
 };
 
-export const DiscoverSourceCard = ({ source, isAdded, onAdd }: DiscoverSourceCardProps) => {
+export const DiscoverSourceCard = ({ source, isAdded, onToggle }: DiscoverSourceCardProps) => {
   return (
     <div
       className={`
@@ -21,26 +21,31 @@ export const DiscoverSourceCard = ({ source, isAdded, onAdd }: DiscoverSourceCar
       `}
     >
       {/* Action indicator */}
-      <div className={`
-        absolute top-3 right-3 w-8 h-8 rounded-full border-2 transition-all duration-200 flex items-center justify-center
-        ${
-          isAdded
-            ? 'border-green-500 dark:border-green-400 bg-green-500 dark:bg-green-400'
-            : 'border-zinc-400 dark:border-zinc-600 bg-transparent group-hover:border-zinc-500 dark:group-hover:border-zinc-500 cursor-pointer'
-        }
-      `}>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggle(source.url);
+        }}
+        className={`
+          absolute top-3 right-3 w-8 h-8 rounded-full border-2 transition-all duration-200 flex items-center justify-center cursor-pointer
+          ${
+            isAdded
+              ? 'border-green-500 dark:border-green-400 bg-green-500 dark:bg-green-400 hover:bg-green-600 dark:hover:bg-green-300'
+              : 'border-zinc-400 dark:border-zinc-600 bg-transparent group-hover:border-zinc-500 dark:group-hover:border-zinc-500 hover:bg-zinc-200 dark:hover:bg-slate-800'
+          }
+          focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-zinc-500 dark:focus-visible:ring-zinc-300 dark:focus-visible:ring-offset-slate-950
+        `}
+        aria-pressed={isAdded}
+        aria-label={isAdded ? 'Remove source' : 'Add source'}
+        title={isAdded ? 'Remove source' : 'Add source'}
+      >
         {isAdded ? (
-          <Check className="w-4 h-4 text-white dark:text-zinc-900" />
+          <Minus className="w-4 h-4 text-white dark:text-zinc-900" />
         ) : (
-          <Plus
-            className="w-4 h-4 text-zinc-700 dark:text-zinc-300 group-hover:text-zinc-800 dark:group-hover:text-zinc-200"
-            onClick={(e) => {
-              e.stopPropagation();
-              onAdd(source.url);
-            }}
-          />
+          <Plus className="w-4 h-4 text-zinc-700 dark:text-zinc-300" />
         )}
-      </div>
+      </button>
 
       {/* Source info */}
       <div className="pr-10 flex items-start gap-3">

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -61,6 +61,7 @@ export const en: TranslationKeys = {
   'sources.selected': 'sources selected',
   'sources.alreadyExists': 'Source already exists!',
   'sources.addedSuccessfully': 'Source added successfully!',
+  'sources.removedSuccessfully': 'Source removed successfully!',
   'sources.noSourcesFound': 'No sources found matching',
   'sources.addCustom': 'Add Custom Source',
   'sources.addCustomSubtitle': 'Add any RSS feed or website by entering its URL',

--- a/src/i18n/translations/es.ts
+++ b/src/i18n/translations/es.ts
@@ -61,6 +61,7 @@ export const es: TranslationKeys = {
   'sources.selected': 'fuentes seleccionadas',
   'sources.alreadyExists': '¡La fuente ya existe!',
   'sources.addedSuccessfully': '¡Fuente agregada exitosamente!',
+  'sources.removedSuccessfully': 'Fuente deseleccionada correctamente.',
   'sources.noSourcesFound': 'No se encontraron fuentes que coincidan con',
   'sources.addCustom': 'Agregar Fuente Personalizada',
   'sources.addCustomSubtitle': 'Agrega cualquier feed RSS o sitio web ingresando su URL',

--- a/src/i18n/translations/fr.ts
+++ b/src/i18n/translations/fr.ts
@@ -61,6 +61,7 @@ export const fr: TranslationKeys = {
   'sources.selected': 'sources sélectionnées',
   'sources.alreadyExists': 'La source existe déjà !',
   'sources.addedSuccessfully': 'Source ajoutée avec succès !',
+  'sources.removedSuccessfully': 'Source retirée avec succès.',
   'sources.noSourcesFound': 'Aucune source trouvée correspondant à',
   'sources.addCustom': 'Ajouter une Source Personnalisée',
   'sources.addCustomSubtitle': 'Ajoutez n\'importe quel flux RSS ou site web en saisissant son URL',

--- a/src/types/i18n.ts
+++ b/src/types/i18n.ts
@@ -67,6 +67,7 @@ export type TranslationKeys = {
   'sources.selected': string;
   'sources.alreadyExists': string;
   'sources.addedSuccessfully': string;
+  'sources.removedSuccessfully': string;
   'sources.noSourcesFound': string;
   'sources.addCustom': string;
   'sources.addCustomSubtitle': string;

--- a/src/views/discover/Discover.tsx
+++ b/src/views/discover/Discover.tsx
@@ -51,10 +51,17 @@ export const Discover = () => {
     setSelectedLanguage(language);
   };
 
-  const handleAddSource = (sourceUrl: string) => {
+  const handleToggleSource = (sourceUrl: string) => {
     const existingSource = state.sources.find(source => source.url === sourceUrl);
+
     if (existingSource) {
-      showError("Source already exists!", "warning");
+      const updatedSources = state.sources.filter(source => source.url !== sourceUrl);
+      const updatedActiveSources = state.activeSources.filter(id => id !== existingSource.id);
+
+      dispatch({ type: ActionTypes.SET_SOURCES, payload: updatedSources });
+      dispatch({ type: ActionTypes.SET_ACTIVE_SOURCES, payload: updatedActiveSources });
+
+      showError(t('sources.removedSuccessfully'), 'info');
       return;
     }
 
@@ -81,7 +88,7 @@ export const Discover = () => {
       dispatch({ type: ActionTypes.SET_SOURCES, payload: [...state.sources, newSource] });
       dispatch({ type: ActionTypes.SET_ACTIVE_SOURCES, payload: [...state.activeSources, sourceId] });
 
-      showError("Source added successfully!", "success");
+      showError(t('sources.addedSuccessfully'), 'success');
     }
   };
 
@@ -195,7 +202,7 @@ export const Discover = () => {
                       key={source.url}
                       source={source}
                       isAdded={addedSourceUrls.has(source.url)}
-                      onAdd={() => handleAddSource(source.url)}
+                      onToggle={handleToggleSource}
                     />
                   ))}
                 </div>

--- a/src/views/ftu/FirstTimeUser.tsx
+++ b/src/views/ftu/FirstTimeUser.tsx
@@ -64,10 +64,17 @@ export const FirstTimeUser = () => {
     setSelectedLanguage(language);
   };
 
-  const handleAddSource = (sourceUrl: string) => {
+  const handleToggleSource = (sourceUrl: string) => {
     const existingSource = state.sources.find(source => source.url === sourceUrl);
+
     if (existingSource) {
-      showError("Source already exists!", "warning");
+      const updatedSources = state.sources.filter(source => source.url !== sourceUrl);
+      const updatedActiveSources = state.activeSources.filter(id => id !== existingSource.id);
+
+      dispatch({ type: ActionTypes.SET_SOURCES, payload: updatedSources });
+      dispatch({ type: ActionTypes.SET_ACTIVE_SOURCES, payload: updatedActiveSources });
+
+      showError(t('sources.removedSuccessfully'), 'info');
       return;
     }
 
@@ -94,7 +101,7 @@ export const FirstTimeUser = () => {
       dispatch({ type: ActionTypes.SET_SOURCES, payload: [...state.sources, newSource] });
       dispatch({ type: ActionTypes.SET_ACTIVE_SOURCES, payload: [...state.activeSources, sourceId] });
 
-      showError("Source added successfully!", "success");
+      showError(t('sources.addedSuccessfully'), 'success');
     }
   };
 
@@ -207,7 +214,7 @@ export const FirstTimeUser = () => {
                       key={source.url}
                       source={source}
                       isAdded={addedSourceUrls.has(source.url)}
-                      onAdd={() => handleAddSource(source.url)}
+                      onToggle={handleToggleSource}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
## Summary
- allow community sources on the FTU and Discover views to be toggled on and off instead of preventing re-selection
- update the DiscoverSourceCard button styling to communicate the remove action when a source is selected
- add localized copy for successful source removal messages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da0955a3d88329aa11671ce2521c6f