### PR TITLE
Add Husky pre-push hook to enforce tests and build

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run test
+TEST_STATUS=$?
+
+if [ $TEST_STATUS -ne 0 ]; then
+  echo "Tests failed. Aborting push."
+  exit $TEST_STATUS
+fi
+
+npm run build
+BUILD_STATUS=$?
+
+if [ $BUILD_STATUS -ne 0 ]; then
+  echo "Build failed. Aborting push."
+  exit $BUILD_STATUS
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.14.0",
+        "husky": "^9.1.7",
         "jsdom": "^27.0.0",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.18.2",
@@ -5708,6 +5709,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ico-endec": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "generate-pwa-assets": "pwa-assets-generator --preset minimal-2023 public/logo.png"
+    "generate-pwa-assets": "pwa-assets-generator --preset minimal-2023 public/logo.png",
+    "prepare": "husky"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.0.4",
@@ -34,6 +35,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",
+    "husky": "^9.1.7",
     "jsdom": "^27.0.0",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",


### PR DESCRIPTION
## Summary
- add husky as a dev dependency and register the prepare script so hooks are installed automatically
- create a pre-push hook that runs the test suite and build, aborting the push if either step fails

## Testing
- npm test -- --reporter=basic
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dca185d9648329b1f8179afff640c1