### PR TITLE
Add Digital Asset Links configuration for TWA

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "app.vercel.localyodis.twa",
+      "sha256_cert_fingerprints": [
+        "96:23:00:6B:E6:82:4D:B0:A0:50:0B:8D:9A:4E:C2:5B:72:FF:ED:19:F4:7A:5B:1B:D0:27:92:DC:85:E8:E9:AB"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add the Digital Asset Links declaration under `.well-known/assetlinks.json` so the TWA can handle all URLs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dca88dd9d48329a0705c954b4d5c9a