### PR TITLE
Add feed refresh pill for new items

### DIFF
--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -154,6 +154,9 @@ export const en: TranslationKeys = {
   'rss.refresh': 'Refresh',
   'rss.link': 'RSS link',
   'rss.example': 'e.g. https://example.com/feed.xml',
+  'rss.newItems': 'new items',
+  'rss.newItem': 'new item',
+  'rss.upToDate': 'Up to date',
   
   // YouTube
   'youtube.channelName': 'Channel name',

--- a/src/i18n/translations/es.ts
+++ b/src/i18n/translations/es.ts
@@ -154,6 +154,9 @@ export const es: TranslationKeys = {
   'rss.refresh': 'Actualizar',
   'rss.link': 'Enlace RSS',
   'rss.example': 'ej. https://ejemplo.com/feed.xml',
+  'rss.newItems': 'nuevos ítems',
+  'rss.newItem': 'nuevo ítem',
+  'rss.upToDate': 'Al día',
   
   // YouTube
   'youtube.channelName': 'Nombre del canal',

--- a/src/i18n/translations/fr.ts
+++ b/src/i18n/translations/fr.ts
@@ -154,6 +154,9 @@ export const fr: TranslationKeys = {
   'rss.refresh': 'Actualiser',
   'rss.link': 'Lien RSS',
   'rss.example': 'ex. https://exemple.com/feed.xml',
+  'rss.newItems': 'nouveaux éléments',
+  'rss.newItem': 'nouvel élément',
+  'rss.upToDate': 'À jour',
   
   // YouTube
   'youtube.channelName': 'Nom de la chaîne',

--- a/src/types/i18n.ts
+++ b/src/types/i18n.ts
@@ -159,6 +159,9 @@ export type TranslationKeys = {
   'rss.refresh': string;
   'rss.link': string;
   'rss.example': string;
+  'rss.newItems': string;
+  'rss.newItem': string;
+  'rss.upToDate': string;
   
   // YouTube
   'youtube.channelName': string;

--- a/src/utils/__tests__/rss.test.ts
+++ b/src/utils/__tests__/rss.test.ts
@@ -1,3 +1,4 @@
+import type { RSSItem } from "../../types/rss";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const modulePath = "../rss";
@@ -38,5 +39,32 @@ describe("rss utilities", () => {
     expect(getRSSItemStrProp({ title: "Hello" } as never, "title")).toBe("Hello");
     expect(getRSSItemStrProp({ title: ["World"] } as never, "title")).toBe("World");
     expect(getRSSItemStrProp({ title: undefined } as never, "title")).toBe("");
+  });
+
+  it("gets rss item links from different formats", async () => {
+    const { getRSSItemLink } = await import(modulePath);
+
+    expect(getRSSItemLink({ link: "https://example.com" } as never)).toBe("https://example.com");
+    expect(getRSSItemLink({ link: ["https://array-link.com"] } as never)).toBe("https://array-link.com");
+    expect(getRSSItemLink({ link: [{ $: { href: "https://object-link.com" } }] } as never)).toBe("https://object-link.com");
+    expect(getRSSItemLink({ id: "fallback-id", link: undefined } as never)).toBe("fallback-id");
+  });
+
+  it("calculates new items count based on identifiers", async () => {
+    const { calculateNewItemsCount } = await import(modulePath);
+
+    const previous: RSSItem[] = [
+      { link: "https://example.com/a", title: "A" } as RSSItem,
+      { id: "persist-id", title: "B" } as RSSItem,
+    ];
+
+    const next: RSSItem[] = [
+      { link: "https://example.com/a", title: "Updated A" } as RSSItem,
+      { link: [{ $: { href: "https://example.com/b" } }] as never, title: "B" } as RSSItem,
+      { id: "persist-id", title: "Still B" } as RSSItem,
+    ];
+
+    expect(calculateNewItemsCount(previous, next)).toBe(1);
+    expect(calculateNewItemsCount([], next)).toBe(0);
   });
 });

--- a/src/utils/rss.ts
+++ b/src/utils/rss.ts
@@ -43,3 +43,84 @@ export const getRSSItemStrProp = (item: RSSItem, prop: keyof RSSItem): string =>
   if (!item[prop]) return "";
   return Array.isArray(item[prop]) ? item[prop][0] : item[prop];
 };
+
+export const getRSSItemLink = (item: RSSItem): string => {
+  if (Array.isArray(item.link) && item.link.length > 0) {
+    const [firstLink] = item.link;
+    if (typeof firstLink === "object" && firstLink && "$" in firstLink && firstLink["$"]?.href) {
+      return firstLink["$"]?.href ?? "";
+    }
+    if (typeof firstLink === "string") {
+      return firstLink;
+    }
+  }
+
+  if (typeof item.link === "string") {
+    return item.link;
+  }
+
+  if (typeof item.id === "string") {
+    return item.id;
+  }
+
+  return "";
+};
+
+export const getRSSItemIdentifier = (item: RSSItem): string => {
+  const link = getRSSItemLink(item);
+  if (link) {
+    return link;
+  }
+
+  if (Array.isArray(item.guid) && item.guid.length > 0) {
+    const [firstGuid] = item.guid;
+    if (typeof firstGuid === "string" && firstGuid) {
+      return firstGuid;
+    }
+  }
+
+  if (typeof item.id === "string" && item.id) {
+    return item.id;
+  }
+
+  const title = getRSSItemStrProp(item, "title");
+  const pubDate = getRSSItemStrProp(item, "pubDate");
+
+  const fallback = `${title}-${pubDate}`.trim();
+  if (fallback !== "-") {
+    return fallback;
+  }
+
+  return title || pubDate;
+};
+
+export const calculateNewItemsCount = (
+  previousItems: RSSItem[] | undefined,
+  nextItems: RSSItem[] | undefined,
+): number => {
+  if (!Array.isArray(previousItems) || previousItems.length === 0) {
+    return 0;
+  }
+
+  if (!Array.isArray(nextItems) || nextItems.length === 0) {
+    return 0;
+  }
+
+  const previousIdentifiers = new Set(
+    previousItems
+      .map(getRSSItemIdentifier)
+      .filter((identifier): identifier is string => Boolean(identifier)),
+  );
+
+  let newItems = 0;
+
+  for (const item of nextItems) {
+    const identifier = getRSSItemIdentifier(item);
+    if (!identifier) continue;
+    if (!previousIdentifiers.has(identifier)) {
+      newItems += 1;
+    }
+  }
+
+  return newItems;
+};


### PR DESCRIPTION
## Summary
- show a sticky pill on the feed that announces new items or confirms when everything is up to date
- centralize RSS item link/identifier helpers and reuse them across the feed
- localize the new pill text in English, Spanish, and French

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcad564a4883298f2fc254d1540736