### PR TITLE
Add pill indicator for new feed items

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Navigations } from "./types/navigation";
 import { PubsList } from "./components/PubList";
 import { SearchInput } from "./components/v2/SearchInput";
 import { SectionIndicator } from "./components/v2/SectionIndicator";
+import { NewItemsPill } from "./components/v2/NewItemsPill";
 import Snackbar from "./components/Snackbar";
 import { useEffect } from "react";
 import { useMainContext } from "./context/main";
@@ -32,6 +33,7 @@ function App() {
       <AdaptiveNavigation>
         {state.navigation === Navigations.SEARCH && <SearchInput />}
         <SectionIndicator />
+        <NewItemsPill />
         <div className="px-8 md:px-6 pt-2 flex flex-col gap-8 max-h-full overflow-scroll items-center bg-white dark:bg-slate-950 hide-scrollbar">
           <PubsList />
         </div>

--- a/src/components/PubList.tsx
+++ b/src/components/PubList.tsx
@@ -110,10 +110,28 @@ export const PubsList = () => {
         
         // Aplicar límites de storage automáticamente
         const limitedItems = applyStorageLimits(newItems);
-        
+
         // Filter out hidden items before saving to localStorage
         const filteredItems = filterHiddenItems(limitedItems, state.hiddenItems);
-        
+
+        const previousItems = state.items || [];
+        const hasExistingItems = previousItems.length > 0;
+        const previousItemLinks = new Set(previousItems.map(extractLink));
+        const newItemsCount = hasExistingItems
+          ? filteredItems.reduce((count, item) => {
+              const link = extractLink(item);
+              return previousItemLinks.has(link) ? count : count + 1;
+            }, 0)
+          : 0;
+
+        dispatch({
+          type: ActionTypes.SET_NEW_ITEMS_STATUS,
+          payload: {
+            count: newItemsCount,
+            status: newItemsCount > 0 ? 'new' : 'upToDate',
+          },
+        });
+
         dispatch({
           type: ActionTypes.SET_ITEMS,
           payload: filteredItems,

--- a/src/components/v2/NewItemsPill.tsx
+++ b/src/components/v2/NewItemsPill.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+
+import { useI18n } from "../../context/i18n";
+import { useMainContext } from "../../context/main";
+
+const DISPLAY_DURATION_MS = 6000;
+
+export const NewItemsPill = () => {
+  const { state } = useMainContext();
+  const { t } = useI18n();
+  const { newItemsCount, latestFetchStatus, navigation, lastUpdated } = state;
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (navigation !== null) {
+      setVisible(false);
+      return;
+    }
+
+    if (latestFetchStatus === "idle") {
+      setVisible(false);
+      return;
+    }
+
+    setVisible(true);
+    const timeoutId = window.setTimeout(() => setVisible(false), DISPLAY_DURATION_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [latestFetchStatus, newItemsCount, navigation, lastUpdated]);
+
+  if (!visible || navigation !== null || latestFetchStatus === "idle") {
+    return null;
+  }
+
+  const hasNewItems = latestFetchStatus === "new" && newItemsCount > 0;
+  const statusLabel = hasNewItems
+    ? `+${newItemsCount} ${t(newItemsCount === 1 ? "feed.newItem" : "feed.newItems")}`
+    : t("feed.upToDate");
+  const baseClasses = hasNewItems
+    ? "bg-blue-600 hover:bg-blue-700"
+    : "bg-emerald-500 hover:bg-emerald-600";
+
+  const handleClick = () => {
+    const listElement = document.getElementById("pubs-list");
+    if (listElement) {
+      listElement.scrollTo({ top: 0, behavior: "smooth" });
+    }
+    setVisible(false);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={`fixed top-24 left-1/2 z-40 -translate-x-1/2 px-4 py-2 rounded-full text-sm font-medium text-white shadow-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-400 dark:focus-visible:ring-blue-300 ${baseClasses}`}
+      aria-live="polite"
+    >
+      {statusLabel}
+    </button>
+  );
+};

--- a/src/context/main/index.tsx
+++ b/src/context/main/index.tsx
@@ -36,6 +36,7 @@ export enum ActionTypes {
   ADD_TO_HISTORY = "ADD_TO_HISTORY",
   CLEAR_HISTORY = "CLEAR_HISTORY",
   REMOVE_FROM_HISTORY = "REMOVE_FROM_HISTORY",
+  SET_NEW_ITEMS_STATUS = "SET_NEW_ITEMS_STATUS",
 }
 
 export const MainContext = createContext<MainContextType | null>(null);

--- a/src/context/main/provider.tsx
+++ b/src/context/main/provider.tsx
@@ -18,6 +18,8 @@ const initialState: LocallyStoredData = {
   bookmarks: localData.bookmarks,
   navigation: localData.navigation || null,
   lastUpdated: localData.lastUpdated,
+  newItemsCount: localData.newItemsCount ?? 0,
+  latestFetchStatus: localData.latestFetchStatus ?? 'idle',
   activeSources: localData.activeSources || localData.sources.map((source) => source.id),
   scrollPosition: localData.scrollPosition,
   loading: localData.loading,
@@ -91,9 +93,15 @@ const reducer = (state: LocallyStoredData, action: Action) => {
     case ActionTypes.CLEAR_HISTORY:
       return { ...state, history: [] };
     case ActionTypes.REMOVE_FROM_HISTORY:
-      return { 
-        ...state, 
+      return {
+        ...state,
         history: state.history.filter(item => item.link !== action.payload)
+      };
+    case ActionTypes.SET_NEW_ITEMS_STATUS:
+      return {
+        ...state,
+        newItemsCount: action.payload.count,
+        latestFetchStatus: action.payload.status,
       };
     default:
       return state;

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -147,7 +147,12 @@ export const en: TranslationKeys = {
   'ftu.sourceReady': 'interest ready',
   'ftu.sourcesReady': 'interests ready',
   'ftu.addInterests': 'Add your interests to get started',
-  
+
+  // Feed
+  'feed.newItems': 'new items',
+  'feed.newItem': 'new item',
+  'feed.upToDate': 'Up to date',
+
   // RSS Feed
   'rss.lastUpdated': 'Last updated',
   'rss.noItems': 'No items available',

--- a/src/i18n/translations/es.ts
+++ b/src/i18n/translations/es.ts
@@ -147,7 +147,12 @@ export const es: TranslationKeys = {
   'ftu.sourceReady': 'interés listo',
   'ftu.sourcesReady': 'intereses listos',
   'ftu.addInterests': 'Añade tus intereses para empezar',
-  
+
+  // Feed
+  'feed.newItems': 'nuevos ítems',
+  'feed.newItem': 'nuevo ítem',
+  'feed.upToDate': 'Al día',
+
   // RSS Feed
   'rss.lastUpdated': 'Última actualización',
   'rss.noItems': 'No hay elementos disponibles',

--- a/src/i18n/translations/fr.ts
+++ b/src/i18n/translations/fr.ts
@@ -148,6 +148,11 @@ export const fr: TranslationKeys = {
   'ftu.sourcesReady': 'intérêts prêts',
   'ftu.addInterests': 'Ajoutez vos intérêts pour commencer',
 
+  // Feed
+  'feed.newItems': 'nouveaux articles',
+  'feed.newItem': 'nouvel article',
+  'feed.upToDate': 'À jour',
+
   // RSS Feed
   'rss.lastUpdated': 'Dernière mise à jour',
   'rss.noItems': 'Aucun élément disponible',

--- a/src/types/i18n.ts
+++ b/src/types/i18n.ts
@@ -152,7 +152,12 @@ export type TranslationKeys = {
   'ftu.sourceReady': string;
   'ftu.sourcesReady': string;
   'ftu.addInterests': string;
-  
+
+  // Feed
+  'feed.newItems': string;
+  'feed.newItem': string;
+  'feed.upToDate': string;
+
   // RSS Feed
   'rss.lastUpdated': string;
   'rss.noItems': string;

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -44,6 +44,8 @@ export type LocallyStoredData = {
   scrollPosition: number;
   loading: boolean;
   lastUpdated: string;
+  newItemsCount: number;
+  latestFetchStatus: 'idle' | 'new' | 'upToDate';
   searchQuery: string | null;
   activeItems: RSSItem[];
   error: ErrorState;

--- a/src/utils/__tests__/storage.test.ts
+++ b/src/utils/__tests__/storage.test.ts
@@ -19,6 +19,8 @@ const createState = (overrides: Partial<LocallyStoredData> = {}): LocallyStoredD
   scrollPosition: 0,
   loading: false,
   lastUpdated: "2024-01-01T00:00:00.000Z",
+  newItemsCount: 0,
+  latestFetchStatus: "idle",
   searchQuery: null,
   activeItems: [],
   error: null,

--- a/src/utils/__tests__/useError.test.ts
+++ b/src/utils/__tests__/useError.test.ts
@@ -19,6 +19,8 @@ vi.mock("../../context/main", async () => {
         scrollPosition: 0,
         loading: false,
         lastUpdated: "2024-01-01T00:00:00.000Z",
+        newItemsCount: 0,
+        latestFetchStatus: "idle",
         searchQuery: null,
         activeItems: [],
         error: null,

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -22,6 +22,8 @@ const defaultLocallyStoredData = {
   navigation: null,
   items: [],
   lastUpdated: new Date().toISOString(),
+  newItemsCount: 0,
+  latestFetchStatus: 'idle',
   searchQuery: null,
   activeItems: [],
   error: null,
@@ -124,6 +126,17 @@ export const getLocallyStoredData = (): LocallyStoredData => {
   // Ensure history exists (for backward compatibility)
   if (!parsedStoredData.history) {
     parsedStoredData.history = [];
+  }
+
+  if (typeof parsedStoredData.newItemsCount !== 'number') {
+    parsedStoredData.newItemsCount = 0;
+  }
+
+  if (
+    parsedStoredData.latestFetchStatus !== 'new' &&
+    parsedStoredData.latestFetchStatus !== 'upToDate'
+  ) {
+    parsedStoredData.latestFetchStatus = 'idle';
   }
 
   // Ensure language exists (for backward compatibility)


### PR DESCRIPTION
## Summary
- add a floating pill component that surfaces the number of new feed items or an up-to-date message
- persist the latest fetch status in state and storage so the indicator can render across sessions
- extend translations and unit tests to cover the new feed status fields

## Testing
- npm test
- npx vitest run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68dcad564a4883298f2fc254d1540736