### PR TITLE
Add analytics tracking helper and translation fallback support

### DIFF
--- a/src/components/v2/PubListItem.tsx
+++ b/src/components/v2/PubListItem.tsx
@@ -2,6 +2,7 @@ import { ActionTypes, useMainContext } from "../../context/main";
 import { Bookmark, BookmarkCheck, EyeOff } from "lucide-react";
 import { HistoryItem, Source } from "../../types/storage";
 import { formatOlderDateTime, formatTime, getDateCategory } from "../../utils/format";
+import { trackEvent } from "../../utils/analytics";
 
 import { RSSItem } from "../../types/rss";
 import { RoundedIdentifier } from "./RoundedIdentifier";
@@ -35,6 +36,10 @@ export const PubListItem = ({ item, index, sourceData, bookmark, onBookmark, onU
   }
 
   const handleSourceClick = () => {
+    trackEvent("source_opened", {
+      sourceId: sourceData.id,
+      sourceName: sourceData.name,
+    });
     navigate(`/sources/${sourceData.id}`);
   };
 
@@ -55,6 +60,30 @@ export const PubListItem = ({ item, index, sourceData, bookmark, onBookmark, onU
 
     // Open link in new tab
     window.open(link, "_blank");
+
+    trackEvent("publication_opened", {
+      sourceId: sourceData.id,
+      sourceName: sourceData.name,
+      link,
+    });
+  };
+
+  const handleBookmark = () => {
+    trackEvent("publication_bookmarked", {
+      sourceId: sourceData.id,
+      sourceName: sourceData.name,
+      link,
+    });
+    onBookmark(item);
+  };
+
+  const handleUnbookmark = () => {
+    trackEvent("publication_unbookmarked", {
+      sourceId: sourceData.id,
+      sourceName: sourceData.name,
+      link,
+    });
+    onUnbookmark(item);
   };
 
   // Swipe gesture handlers
@@ -95,6 +124,11 @@ export const PubListItem = ({ item, index, sourceData, bookmark, onBookmark, onU
       
       // Hide item after animation completes (300ms)
       setTimeout(() => {
+        trackEvent("publication_hidden", {
+          sourceId: sourceData.id,
+          sourceName: sourceData.name,
+          link,
+        });
         onHide(item);
       }, 300);
     } else {
@@ -185,7 +219,7 @@ export const PubListItem = ({ item, index, sourceData, bookmark, onBookmark, onU
             {bookmark !== undefined ? (
               <button
                 className="text-gray-700 dark:text-gray-200 cursor-pointer hover:text-blue-600 dark:hover:text-blue-400 transition-colors p-1"
-                onClick={() => onUnbookmark(item)}
+                onClick={handleUnbookmark}
               >
                 <BookmarkCheck
                   className="h-4 w-4"
@@ -195,7 +229,7 @@ export const PubListItem = ({ item, index, sourceData, bookmark, onBookmark, onU
             ) : (
               <button
                 className="text-gray-700 dark:text-gray-200 cursor-pointer hover:text-blue-600 dark:hover:text-blue-400 transition-colors p-1"
-                onClick={() => onBookmark(item)}
+                onClick={handleBookmark}
               >
                 <Bookmark className="h-4 w-4 text-gray-800 dark:text-gray-400" />
               </button>

--- a/src/context/i18n/index.tsx
+++ b/src/context/i18n/index.tsx
@@ -6,7 +6,7 @@ import { en } from '../../i18n/translations/en';
 interface I18nContextType {
   language: SupportedLanguage;
   setLanguage: (language: SupportedLanguage) => void;
-  t: (key: keyof typeof en) => string;
+  t: (key: keyof typeof en, fallback?: string) => string;
   languages: typeof SUPPORTED_LANGUAGES;
 }
 
@@ -33,8 +33,8 @@ export const I18nProvider = ({ children }: { children: ReactNode }) => {
   };
 
   // Translation function
-  const t = (key: keyof typeof en): string => {
-    return getTranslation(language, key);
+  const t = (key: keyof typeof en, fallback?: string): string => {
+    return getTranslation(language, key, fallback);
   };
 
   // Update HTML lang attribute when language changes

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -42,14 +42,15 @@ export const getBrowserLanguage = (): SupportedLanguage => {
 // Utility function to get translation by key
 export const getTranslation = (
   language: SupportedLanguage,
-  key: keyof typeof en
+  key: keyof typeof en,
+  fallback?: string
 ): string => {
   const langTranslations = translations[language];
   if (!langTranslations) {
-    return translations[DEFAULT_LANGUAGE]?.[key] || key;
+    return translations[DEFAULT_LANGUAGE]?.[key] || fallback || key;
   }
-  
-  return langTranslations[key] || translations[DEFAULT_LANGUAGE]?.[key] || key;
+
+  return langTranslations[key] || translations[DEFAULT_LANGUAGE]?.[key] || fallback || key;
 };
 
 // Utility function to get language option by code

--- a/src/utils/__tests__/i18n.test.ts
+++ b/src/utils/__tests__/i18n.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { LanguageOption } from "../../types/i18n";
+import { en } from "../../i18n/translations/en";
 
 const modulePath = "../../i18n";
 
@@ -20,7 +21,15 @@ describe("i18n utilities", () => {
   it("returns translations and language options", async () => {
     const { getTranslation, getLanguageOption } = await import(modulePath);
     expect(getTranslation("en", "home")).toBe("Home");
+    expect(getTranslation("en", "home", "Fallback")).toBe("Home");
     expect(getTranslation("unknown" as never, "home")).toBe("Home");
     expect(getLanguageOption("en")).toEqual(expect.objectContaining({ code: "en" }));
+  });
+
+  it("uses fallback when translation is not available", async () => {
+    const { getTranslation } = await import(modulePath);
+    expect(
+      getTranslation("en", "nonexistent.key" as keyof typeof en, "Fallback")
+    ).toBe("Fallback");
   });
 });

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,36 @@
+export type TrackEventPayload = Record<string, string | number | boolean | null | undefined>;
+
+declare global {
+  interface Window {
+    plausible?: (event: string, options?: { props?: Record<string, unknown> }) => void;
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+const sanitizePayload = (payload?: TrackEventPayload) => {
+  if (!payload) return undefined;
+
+  return Object.entries(payload).reduce<Record<string, string | number | boolean | null>>((acc, [key, value]) => {
+    if (value !== undefined) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+};
+
+export const trackEvent = (event: string, payload?: TrackEventPayload) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const sanitized = sanitizePayload(payload);
+
+  if (typeof window.plausible === "function") {
+    window.plausible(event, sanitized ? { props: sanitized } : undefined);
+    return;
+  }
+
+  if (typeof window.gtag === "function") {
+    window.gtag("event", event, sanitized ?? {});
+  }
+};


### PR DESCRIPTION
## Summary
- add a reusable analytics tracker utility and hook it into publication interactions
- allow i18n translations to accept an optional fallback and cover it with tests

## Testing
- npx vitest run --reporter=basic
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1e4e3ce388329b055f80558dd622e