### PR TITLE
Fix service worker cache update for deploys

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker para LocalYodis
 // Mantiene el registro básico sin notificaciones push ni background sync
 
-const APP_SHELL_CACHE = "localyodis-app-shell-v1";
+const APP_SHELL_CACHE = "localyodis-app-shell-v2";
 const APP_SHELL_FILES = ["/index.html"];
 
 self.addEventListener("install", (event) => {
@@ -12,7 +12,17 @@ self.addEventListener("install", (event) => {
 });
 
 self.addEventListener("activate", (event) => {
-  event.waitUntil(self.clients.claim());
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter((key) => key !== APP_SHELL_CACHE)
+          .map((key) => caches.delete(key))
+      );
+      await self.clients.claim();
+    })()
+  );
 });
 
 self.addEventListener("fetch", (event) => {
@@ -21,12 +31,19 @@ self.addEventListener("fetch", (event) => {
   }
 
   event.respondWith(
-    caches.match("/index.html").then((cachedResponse) => {
-      if (cachedResponse) {
-        return cachedResponse;
+    (async () => {
+      try {
+        const response = await fetch("/index.html", { cache: "no-store" });
+        const cache = await caches.open(APP_SHELL_CACHE);
+        await cache.put("/index.html", response.clone());
+        return response;
+      } catch (error) {
+        const cachedResponse = await caches.match("/index.html");
+        if (cachedResponse) {
+          return cachedResponse;
+        }
+        throw error;
       }
-
-      return fetch("/index.html", { cache: "no-store" });
-    })
+    })()
   );
 });


### PR DESCRIPTION
### Motivation
- Prevent the app showing a blank/whitescreen after new deployments caused by a stale cached `index.html`.
- Ensure the service worker updates the app shell cache when a new deployment is available.
- Avoid serving outdated HTML to users by preferring a fresh network response for navigations.

### Description
- Bumped the app shell cache name to `APP_SHELL_CACHE = "localyodis-app-shell-v2"` to force a cache version change.
- On `activate` the worker now deletes old caches that do not match `APP_SHELL_CACHE` before calling `self.clients.claim()`.
- The `fetch` handler for navigation requests uses a network-first strategy: it fetches `/index.html` with `cache: "no-store"`, updates the cache with the fresh response, and falls back to the cached `index.html` if the network request fails.

### Testing
- Ran the test suite with `npm test` (Vitest) as the automated check for regressions.
- Automated tests completed successfully with `10` test files and `38` tests passed.
- The test run showed a runtime warning about `act(...)` environment configuration but finished without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696570faecb48329bdf37445b9a73bb9)